### PR TITLE
Corrected duplicate & added Block Win32 API from Macro

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -214,8 +214,8 @@ if (Get-Command "Set-MpPreference" -errorAction SilentlyContinue)
     # Block Office applications from injecting code into other processes
     Set-MpPreference -AttackSurfaceReductionRules_Ids 75668C1F-73B5-4CF0-BB93-3ECF5CB7CC84 -AttackSurfaceReductionRules_Actions Enabled -errorAction SilentlyContinue
 
-    # Block Office applications from injecting code into other processes
-    Set-MpPreference -AttackSurfaceReductionRules_Ids 75668C1F-73B5-4CF0-BB93-3ECF5CB7CC84 -AttackSurfaceReductionRules_Actions Enabled -errorAction SilentlyContinue
+    # Block Win32 API calls from Office macros
+    Set-MpPreference -AttackSurfaceReductionRules_Ids 92e97fa1-2edf-4476-bdd6-9dd0b4dddc7b -AttackSurfaceReductionRules_Actions Enabled -errorAction SilentlyContinue
 
     # Block execution of potentially obfuscated scripts
     Set-MpPreference -AttackSurfaceReductionRules_Ids 5BEB7EFE-FD9A-4556-801D-275E5FFC04CC -AttackSurfaceReductionRules_Actions Enabled -errorAction SilentlyContinue


### PR DESCRIPTION
See https://docs.microsoft.com/en-us/microsoft-365/security/defender-endpoint/attack-surface-reduction-rules-reference?view=o365-worldwide#block-win32-api-calls-from-office-macros
